### PR TITLE
Fix program bugs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "window.commandCenter": 1,
+    "window.commandCenter": true,
     "explorer.confirmDelete": false,
     "debug.javascript.autoAttachFilter": "disabled",
     "redhat.telemetry.enabled": false,


### PR DESCRIPTION
A change was made to `.vscode/settings.json`.

The `"window.commandCenter"` setting was updated:
*   Its value was changed from `1` to `true`.

This adjustment corrects the data type for the setting, as `1` is not a valid boolean literal in JSON for this context, while `true` correctly represents the intended boolean state.